### PR TITLE
Warning in the console if same name pan elements are available on the page. 

### DIFF
--- a/resources/js/src/main.ts
+++ b/resources/js/src/main.ts
@@ -139,7 +139,7 @@ if (window.__pan.inertiaStartListener) {
 
             let nameElements = document.querySelectorAll(`[data-pan='${name}']`);
             if (nameElements.length > 1 && !sameNameElements.includes(name)) {
-                console.warn('PAN: Multiple elements with the same name detected: ', name);
+                console.warn(`PAN: Multiple (${nameElements.length}) elements with the same name '${name}' found`);
                 sameNameElements.push(name);
             }
 


### PR DESCRIPTION
The current behavior of the package takes the last element on the page into consideration, ignoring all others. But the user doesn't know if by mistake that happened.

This PR will give the user a warning in the console if any pan element has the same name.  It's a warning because the package must have broken it would have been an error. 

On-Page 
![image](https://github.com/user-attachments/assets/baf175f5-5478-4c90-9965-eda70c32dfae)

In Console.
![image](https://github.com/user-attachments/assets/c9cbdaf3-0705-404e-98a3-9b5e9954f864)
