### PR TITLE
Add support to change the route prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ use Pan\PanConfiguration;
 
 public function register(): void
 {
-    PanConfiguration::prefixUrl('new-pan');
+    PanConfiguration::routePrefix('new-pan');
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ To flush your product analytics, you may use the `pan:flush` Artisan command:
 php artisan pan:flush
 ```
 
+## Change `/pan/*` endpoints
+By default, Pan sets the endpoints to have the prefix of `/pan`, but if you want to change it, you can by doing this:
+
+```php
+use Pan\PanConfiguration;
+
+public function register(): void
+{
+    PanConfiguration::prefixUrl('new-pan');
+}
+```
+
+With that set the url to track the analytics will be `/new-pan/events`.
+
 ## How does it work?
 
 Via middleware, Pan injects a simple JavaScript library into your HTML pages. This library listens to events like `viewed`, `clicked`, or `hovered` and sends the data to your Laravel application. Note that this library does not collect any personal information; such as IP addresses, user agents, or any information that could be used to identify a user.

--- a/resources/js/src/main.ts
+++ b/resources/js/src/main.ts
@@ -8,7 +8,7 @@ window.__pan =
     window.__pan ||
     ({
         csrfToken: "%_PAN_CSRF_TOKEN_%",
-        prefixUrl: "%_PAN_PREFIX_URL_%",
+        routePrefix: "%_PAN_ROUTE_PREFIX_%",
         observer: null,
         clickListener: null,
         mouseoverListener: null,
@@ -71,7 +71,7 @@ if (window.__pan.inertiaStartListener) {
         queue = [];
 
         navigator.sendBeacon(
-            `/${window.__pan.prefixUrl}/events`,
+            `/${window.__pan.routePrefix}/events`,
             new Blob(
                 [
                     JSON.stringify({

--- a/resources/js/src/main.ts
+++ b/resources/js/src/main.ts
@@ -8,6 +8,7 @@ window.__pan =
     window.__pan ||
     ({
         csrfToken: "%_PAN_CSRF_TOKEN_%",
+        prefixUrl: "%_PAN_PREFIX_URL_%",
         observer: null,
         clickListener: null,
         mouseoverListener: null,
@@ -70,7 +71,7 @@ if (window.__pan.inertiaStartListener) {
         queue = [];
 
         navigator.sendBeacon(
-            "/pan/events",
+            `/${window.__pan.prefixUrl}/events`,
             new Blob(
                 [
                     JSON.stringify({
@@ -134,7 +135,7 @@ if (window.__pan.inertiaStartListener) {
         const elementsBeingImpressed = document.querySelectorAll("[data-pan]");
 
         elementsBeingImpressed.forEach((element: Element): void => {
-            if (! element.checkVisibility()) {
+            if (!element.checkVisibility()) {
                 return;
             }
 

--- a/resources/js/src/types.ts
+++ b/resources/js/src/types.ts
@@ -2,6 +2,7 @@ export type EventType = "click" | "hover" | "impression";
 
 export type GlobalState = {
     csrfToken: string;
+    prefixUrl: string;
     observer: MutationObserver | null;
     clickListener: EventListener | null;
     mouseoverListener: EventListener | null;

--- a/resources/js/src/types.ts
+++ b/resources/js/src/types.ts
@@ -2,7 +2,7 @@ export type EventType = "click" | "hover" | "impression";
 
 export type GlobalState = {
     csrfToken: string;
-    prefixUrl: string;
+    routePrefix: string;
     observer: MutationObserver | null;
     clickListener: EventListener | null;
     mouseoverListener: EventListener | null;

--- a/src/Adapters/Laravel/Http/Middleware/InjectJavascriptLibrary.php
+++ b/src/Adapters/Laravel/Http/Middleware/InjectJavascriptLibrary.php
@@ -45,7 +45,7 @@ final readonly class InjectJavascriptLibrary
     {
         $original = $response->original ?? null;
 
-        ['prefix_url' => $prefixUrl] = app(PanConfiguration::class)->toArray();
+        ['route_prefix' => $routePrefix] = app(PanConfiguration::class)->toArray();
 
         $response->setContent(
             str_replace(
@@ -57,8 +57,8 @@ final readonly class InjectJavascriptLibrary
                         </body>
                         HTML,
                     str_replace(
-                        ['%_PAN_CSRF_TOKEN_%', '%_PAN_PREFIX_URL_%'],
-                        [(string) csrf_token(), $prefixUrl],
+                        ['%_PAN_CSRF_TOKEN_%', '%_PAN_ROUTE_PREFIX_%'],
+                        [(string) csrf_token(), $routePrefix],
                         File::get(__DIR__.'/../../../../../resources/js/dist/pan.iife.js')
                     ),
                 ),

--- a/src/Adapters/Laravel/Http/Middleware/InjectJavascriptLibrary.php
+++ b/src/Adapters/Laravel/Http/Middleware/InjectJavascriptLibrary.php
@@ -7,6 +7,7 @@ namespace Pan\Adapters\Laravel\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\File;
+use Pan\PanConfiguration;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -44,6 +45,8 @@ final readonly class InjectJavascriptLibrary
     {
         $original = $response->original ?? null;
 
+        ['prefix_url' => $prefixUrl] = app(PanConfiguration::class)->toArray();
+
         $response->setContent(
             str_replace(
                 '</body>',
@@ -53,7 +56,11 @@ final readonly class InjectJavascriptLibrary
                             </script>
                         </body>
                         HTML,
-                    str_replace('%_PAN_CSRF_TOKEN_%', (string) csrf_token(), File::get(__DIR__.'/../../../../../resources/js/dist/pan.iife.js')),
+                    str_replace(
+                        ['%_PAN_CSRF_TOKEN_%', '%_PAN_PREFIX_URL_%'],
+                        [(string) csrf_token(), $prefixUrl],
+                        File::get(__DIR__.'/../../../../../resources/js/dist/pan.iife.js')
+                    ),
                 ),
                 (string) $response->getContent(),
             )

--- a/src/Adapters/Laravel/Providers/PanServiceProvider.php
+++ b/src/Adapters/Laravel/Providers/PanServiceProvider.php
@@ -69,7 +69,7 @@ final class PanServiceProvider extends ServiceProvider
         /** @var PanConfiguration $config */
         $config = $this->app->get(PanConfiguration::class);
 
-        Route::prefix($config->toArray()['prefix_url'])->group(function (): void {
+        Route::prefix($config->toArray()['route_prefix'])->group(function (): void {
             Route::post('/events', [EventController::class, 'store']);
         });
     }

--- a/src/Adapters/Laravel/Providers/PanServiceProvider.php
+++ b/src/Adapters/Laravel/Providers/PanServiceProvider.php
@@ -66,7 +66,10 @@ final class PanServiceProvider extends ServiceProvider
 
         $kernel->pushMiddleware(InjectJavascriptLibrary::class);
 
-        Route::prefix('pan')->group(function (): void {
+        /** @var PanConfiguration $config */
+        $config = $this->app->get(PanConfiguration::class);
+
+        Route::prefix($config->toArray()['prefix_url'])->group(function (): void {
             Route::post('/events', [EventController::class, 'store']);
         });
     }

--- a/src/PanConfiguration.php
+++ b/src/PanConfiguration.php
@@ -22,7 +22,7 @@ final class PanConfiguration
     private function __construct(
         private int $maxAnalytics = 50,
         private array $allowedAnalytics = [],
-        private string $prefixUrl = 'pan',
+        private string $routePrefix = 'pan',
     ) {
         //
     }
@@ -60,13 +60,13 @@ final class PanConfiguration
     }
 
     /**
-     * Sets the prefix url to be used.
+     * Sets the route prefix to be used.
      *
      * @internal
      */
-    public function setPrefixUrl(string $url): void
+    public function setRoutePrefix(string $prefix): void
     {
-        $this->prefixUrl = $url;
+        $this->routePrefix = $prefix;
     }
 
     /**
@@ -96,13 +96,13 @@ final class PanConfiguration
     }
 
     /**
-     * Sets the prefix url to be used.
+     * Sets the route prefix to be used.
      *
      * @internal
      */
-    public static function prefixUrl(string $url): void
+    public static function routePrefix(string $prefix): void
     {
-        self::instance()->setPrefixUrl($url);
+        self::instance()->setRoutePrefix($prefix);
     }
 
     /**
@@ -114,13 +114,13 @@ final class PanConfiguration
     {
         self::maxAnalytics(50);
         self::allowedAnalytics([]);
-        self::prefixUrl('pan');
+        self::routePrefix('pan');
     }
 
     /**
      * Converts the Pan configuration to an array.
      *
-     * @return array{max_analytics: int, allowed_analytics: array<int, string>, prefix_url: string}
+     * @return array{max_analytics: int, allowed_analytics: array<int, string>, route_prefix: string}
      *
      * @internal
      */
@@ -129,7 +129,7 @@ final class PanConfiguration
         return [
             'max_analytics' => $this->maxAnalytics,
             'allowed_analytics' => $this->allowedAnalytics,
-            'prefix_url' => $this->prefixUrl,
+            'route_prefix' => $this->routePrefix,
         ];
     }
 }

--- a/src/PanConfiguration.php
+++ b/src/PanConfiguration.php
@@ -22,6 +22,7 @@ final class PanConfiguration
     private function __construct(
         private int $maxAnalytics = 50,
         private array $allowedAnalytics = [],
+        private string $prefixUrl = 'pan',
     ) {
         //
     }
@@ -59,6 +60,16 @@ final class PanConfiguration
     }
 
     /**
+     * Sets the prefix url to be used.
+     *
+     * @internal
+     */
+    public function setPrefixUrl(string $url): void
+    {
+        $this->prefixUrl = $url;
+    }
+
+    /**
      * Sets the maximum number of analytics to store.
      */
     public static function maxAnalytics(int $number): void
@@ -85,6 +96,16 @@ final class PanConfiguration
     }
 
     /**
+     * Sets the prefix url to be used.
+     *
+     * @internal
+     */
+    public static function prefixUrl(string $url): void
+    {
+        self::instance()->setPrefixUrl($url);
+    }
+
+    /**
      * Resets the configuration to its default values.
      *
      * @internal
@@ -93,12 +114,13 @@ final class PanConfiguration
     {
         self::maxAnalytics(50);
         self::allowedAnalytics([]);
+        self::prefixUrl('pan');
     }
 
     /**
      * Converts the Pan configuration to an array.
      *
-     * @return array{max_analytics: int, allowed_analytics: array<int, string>}
+     * @return array{max_analytics: int, allowed_analytics: array<int, string>, prefix_url: string}
      *
      * @internal
      */
@@ -107,6 +129,7 @@ final class PanConfiguration
         return [
             'max_analytics' => $this->maxAnalytics,
             'allowed_analytics' => $this->allowedAnalytics,
+            'prefix_url' => $this->prefixUrl,
         ];
     }
 }

--- a/tests/Feature/Laravel/Http/EventsTest.php
+++ b/tests/Feature/Laravel/Http/EventsTest.php
@@ -96,6 +96,30 @@ it('does not create an analytic event if the event is invalid', function (): voi
     expect($analytics)->toBe([]);
 });
 
+it('can create an event using a custom prefix url', function (): void {
+    PanConfiguration::instance()->setPrefixUrl('new-pan');
+
+    $this->reloadApplication();
+
+    $response = $this->post('/new-pan/events', [
+        'events' => [[
+            'name' => 'help-modal',
+            'type' => 'impression',
+        ]],
+    ]);
+
+    $response->assertStatus(204);
+
+    $analytics = array_map(fn (Analytic $analytic): array => $analytic->toArray(), app(AnalyticsRepository::class)->all());
+
+    expect($analytics)->toBe([
+        ['id' => 1, 'name' => 'help-modal', 'impressions' => 1, 'hovers' => 0, 'clicks' => 0],
+    ]);
+})->after(function (): void {
+    PanConfiguration::instance()->setPrefixUrl('pan');
+    $this->reloadApplication();
+});
+
 it('does handle gracefully when there is more than 50 analytics created by default', function (): void {
     DB::table('pan_analytics')->insert(array_map(fn (int $index): array => [
         'name' => "help-modal-$index",

--- a/tests/Feature/Laravel/Http/EventsTest.php
+++ b/tests/Feature/Laravel/Http/EventsTest.php
@@ -97,7 +97,7 @@ it('does not create an analytic event if the event is invalid', function (): voi
 });
 
 it('can create an event using a custom prefix url', function (): void {
-    PanConfiguration::instance()->setPrefixUrl('new-pan');
+    PanConfiguration::instance()->setRoutePrefix('new-pan');
 
     $this->reloadApplication();
 
@@ -116,7 +116,7 @@ it('can create an event using a custom prefix url', function (): void {
         ['id' => 1, 'name' => 'help-modal', 'impressions' => 1, 'hovers' => 0, 'clicks' => 0],
     ]);
 })->after(function (): void {
-    PanConfiguration::instance()->setPrefixUrl('pan');
+    PanConfiguration::instance()->setRoutePrefix('pan');
     $this->reloadApplication();
 });
 

--- a/tests/Unit/PanConfigurationTest.php
+++ b/tests/Unit/PanConfigurationTest.php
@@ -6,7 +6,7 @@ it('have a max of 50 analytics by default', function (): void {
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => 50,
         'allowed_analytics' => [],
-        'prefix_url' => 'pan',
+        'route_prefix' => 'pan',
     ]);
 });
 
@@ -16,7 +16,7 @@ it('can set the max number of analytics to store', function (): void {
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => 100,
         'allowed_analytics' => [],
-        'prefix_url' => 'pan',
+        'route_prefix' => 'pan',
     ]);
 });
 
@@ -26,7 +26,7 @@ it('can set the max number of analytics to unlimited', function (): void {
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => PHP_INT_MAX,
         'allowed_analytics' => [],
-        'prefix_url' => 'pan',
+        'route_prefix' => 'pan',
     ]);
 });
 
@@ -36,7 +36,7 @@ it('can set the allowed analytics names to store', function (): void {
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => 50,
         'allowed_analytics' => ['help-modal', 'contact-modal'],
-        'prefix_url' => 'pan',
+        'route_prefix' => 'pan',
     ]);
 });
 
@@ -44,29 +44,29 @@ it('sets an empty array of allowed analytics names by default', function (): voi
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => 50,
         'allowed_analytics' => [],
-        'prefix_url' => 'pan',
+        'route_prefix' => 'pan',
     ]);
 });
 
 it('can set the prefix url', function (): void {
-    PanConfiguration::prefixUrl('new-pan');
+    PanConfiguration::routePrefix('new-pan');
 
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => 50,
         'allowed_analytics' => [],
-        'prefix_url' => 'new-pan',
+        'route_prefix' => 'new-pan',
     ]);
 });
 
 it('may reset the configuration to its default values', function (): void {
     PanConfiguration::maxAnalytics(99);
     PanConfiguration::allowedAnalytics(['help-modal', 'contact-modal']);
-    PanConfiguration::prefixUrl('new-pan');
+    PanConfiguration::routePrefix('new-pan');
 
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => 99,
         'allowed_analytics' => ['help-modal', 'contact-modal'],
-        'prefix_url' => 'new-pan',
+        'route_prefix' => 'new-pan',
     ]);
 
     PanConfiguration::reset();
@@ -74,6 +74,6 @@ it('may reset the configuration to its default values', function (): void {
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => 50,
         'allowed_analytics' => [],
-        'prefix_url' => 'pan',
+        'route_prefix' => 'pan',
     ]);
 });

--- a/tests/Unit/PanConfigurationTest.php
+++ b/tests/Unit/PanConfigurationTest.php
@@ -6,6 +6,7 @@ it('have a max of 50 analytics by default', function (): void {
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => 50,
         'allowed_analytics' => [],
+        'prefix_url' => 'pan',
     ]);
 });
 
@@ -15,6 +16,7 @@ it('can set the max number of analytics to store', function (): void {
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => 100,
         'allowed_analytics' => [],
+        'prefix_url' => 'pan',
     ]);
 });
 
@@ -24,6 +26,7 @@ it('can set the max number of analytics to unlimited', function (): void {
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => PHP_INT_MAX,
         'allowed_analytics' => [],
+        'prefix_url' => 'pan',
     ]);
 });
 
@@ -33,6 +36,7 @@ it('can set the allowed analytics names to store', function (): void {
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => 50,
         'allowed_analytics' => ['help-modal', 'contact-modal'],
+        'prefix_url' => 'pan',
     ]);
 });
 
@@ -40,16 +44,29 @@ it('sets an empty array of allowed analytics names by default', function (): voi
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => 50,
         'allowed_analytics' => [],
+        'prefix_url' => 'pan',
+    ]);
+});
+
+it('can set the prefix url', function (): void {
+    PanConfiguration::prefixUrl('new-pan');
+
+    expect(PanConfiguration::instance()->toArray())->toBe([
+        'max_analytics' => 50,
+        'allowed_analytics' => [],
+        'prefix_url' => 'new-pan',
     ]);
 });
 
 it('may reset the configuration to its default values', function (): void {
     PanConfiguration::maxAnalytics(99);
     PanConfiguration::allowedAnalytics(['help-modal', 'contact-modal']);
+    PanConfiguration::prefixUrl('new-pan');
 
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => 99,
         'allowed_analytics' => ['help-modal', 'contact-modal'],
+        'prefix_url' => 'new-pan',
     ]);
 
     PanConfiguration::reset();
@@ -57,5 +74,6 @@ it('may reset the configuration to its default values', function (): void {
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => 50,
         'allowed_analytics' => [],
+        'prefix_url' => 'pan',
     ]);
 });


### PR DESCRIPTION
This PR adds the capability to the the route prefix from `/pan/*` to `/custom-pan-path/*` by setting:

```php
PanConfiguration::routePrefix('custom-pan-path');
```

> We could also go with a `config/pan.php` approach but since that there was a `PanConfiguration` class I did follow the same path.

Cheers 🍻