### PR TITLE
Add note to README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Finally, you may start tracking your pages or components adding the `data-pan` a
 </div>
 ```
 
+> [!IMPORTANT]  
+> Event names must only contain letters, numbers, dashes, and underscores.
+
 ## Visualize your product analytics
 
 To visualize your product analytics, you may use the `pan` Artisan command:


### PR DESCRIPTION
This PR adds the following notice to the README:

> [!IMPORTANT]  
> Event names must only contain letters, numbers, dashes, and underscores.

I feel this is important otherwise users may wonder why certain events do not appear to be tracked.

There's probably a case for allowing periods `.` in event names but that can be a separate PR.

Background:
Without diving into the source code, it wasn't obvious to me that certain event names would be discarded. In my case it was a `quote-form.started` event, which took inspiration from cache key naming conventions in Laravel.