### PR TITLE
Replace `regex` rule with `alpha_dash:ascii`

### DIFF
--- a/src/Adapters/Laravel/Http/Requests/CreateEventRequest.php
+++ b/src/Adapters/Laravel/Http/Requests/CreateEventRequest.php
@@ -22,7 +22,7 @@ final class CreateEventRequest extends FormRequest
     {
         return [
             'events' => ['required', 'array'],
-            'events.*.name' => ['required', 'string', 'regex:/^[A-Za-z0-9-_]+$/'],
+            'events.*.name' => ['required', 'string', 'alpha_dash:ascii'],
             'events.*.type' => ['required', Rule::enum(EventType::class)],
         ];
     }

--- a/tests/Feature/Laravel/Http/EventsTest.php
+++ b/tests/Feature/Laravel/Http/EventsTest.php
@@ -79,6 +79,28 @@ it('can create an analytic impression event and click event', function (): void 
     ]);
 });
 
+it('does not create an analytic event if the event name is invalid', function (string $name): void {
+    $response = $this->post('/pan/events', [
+        'events' => [[
+            'name' => $name,
+            'type' => 'impression',
+        ]],
+    ]);
+
+    $response->assertStatus(302)->assertSessionHasErrors([
+        'events.0.name' => 'The events.0.name field must only contain letters, numbers, dashes, and underscores.',
+    ]);
+
+    $analytics = array_map(fn (Analytic $analytic): array => $analytic->toArray(), app(AnalyticsRepository::class)->all());
+
+    expect($analytics)->toBe([]);
+})->with([
+    'help modal',
+    'help.modal',
+    'help/modal',
+    '🙋',
+]);
+
 it('does not create an analytic event if the event is invalid', function (): void {
     $response = $this->post('/pan/events', [
         'events' => [[


### PR DESCRIPTION
This PR replaces the event name regex validation from:

`/^[A-Za-z0-9-_]+$/`

to Laravel's `alpha_dash:ascii` which is:

`/\A[a-zA-Z0-9_-]+\z/u`

Whilst the outcome is essentially the same, the latter rule is superior as it matches the absolute start/end of the string and enforces Unicode pattern matching.

I've also added a test case for this rule.