### PR TITLE
Add ability to define descriptions per Analytic item

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ If you want to have unlimited analytics records, you may use the `Pan::unlimited
 PanConfiguration::unlimitedAnalytics();
 ```
 
+## Provide a human description for your analytics
+
+If you want to add a human-readable description to your analytics, you may use the `PanConfiguration::analyticsDescriptions` method:
+
+```php
+PanConfiguration::analyticDescriptions([
+    'button-cta' => 'Call to action button',
+]);
+```
+
+These descriptions will be shown when you visualize your analytics via the `pan` Artisan command.
+
 ## Configure the route prefix
 
 By default, Pan's route prefix is `/pan`, but you may change it by using the `PanConfiguration::routePrefix` method:

--- a/src/Adapters/Laravel/Console/Commands/PanCommand.php
+++ b/src/Adapters/Laravel/Console/Commands/PanCommand.php
@@ -47,7 +47,7 @@ final class PanCommand extends Command
         }
 
         (new Table($this->output))->display(
-            ['', 'Name', 'Impressions', 'Hovers', 'Clicks'],
+            ['', 'Name', 'Description', 'Impressions', 'Hovers', 'Clicks'],
             array_map(fn (Analytic $analytic): array => array_values($presentor->present($analytic)), $analytics)
         );
     }

--- a/src/Adapters/Laravel/Repositories/DatabaseAnalyticsRepository.php
+++ b/src/Adapters/Laravel/Repositories/DatabaseAnalyticsRepository.php
@@ -16,11 +16,21 @@ use Pan\ValueObjects\Analytic;
 final readonly class DatabaseAnalyticsRepository implements AnalyticsRepository
 {
     /**
+     * @var array{
+     *      max_analytics: int,
+     *      allowed_analytics: array<int, string>,
+     *      route_prefix: string,
+     *      analytic_descriptions: array<string, string>,
+     *  }
+     */
+    private array $config;
+
+    /**
      * Creates a new analytics repository instance.
      */
-    public function __construct(private PanConfiguration $config)
+    public function __construct(PanConfiguration $config)
     {
-        //
+        $this->config = $config->toArray();
     }
 
     /**
@@ -36,7 +46,8 @@ final readonly class DatabaseAnalyticsRepository implements AnalyticsRepository
             name: $analytic->name, // @phpstan-ignore-line
             impressions: (int) $analytic->impressions, // @phpstan-ignore-line
             hovers: (int) $analytic->hovers, // @phpstan-ignore-line
-            clicks: (int) $analytic->clicks, // @phpstan-ignore-line
+            clicks: (int) $analytic->clicks, // @phpstan-ignore-line,
+            description: $this->config['analytic_descriptions'][$analytic->name] ?? null, // @phpstan-ignore-line
         ))->toArray();
 
         return $all;
@@ -50,7 +61,7 @@ final readonly class DatabaseAnalyticsRepository implements AnalyticsRepository
         [
             'allowed_analytics' => $allowedAnalytics,
             'max_analytics' => $maxAnalytics,
-        ] = $this->config->toArray();
+        ] = $this->config;
 
         if (count($allowedAnalytics) > 0 && ! in_array($name, $allowedAnalytics, true)) {
             return;

--- a/src/PanConfiguration.php
+++ b/src/PanConfiguration.php
@@ -15,11 +15,13 @@ final class PanConfiguration
      * Creates a new Pan configuration instance.
      *
      * @param  array<int, string>  $allowedAnalytics
+     * @param  array<string, string>  $analyticDescriptions
      */
     private function __construct(
         private int $maxAnalytics = 50,
         private array $allowedAnalytics = [],
         private string $routePrefix = 'pan',
+        private array $analyticDescriptions = [],
     ) {
         //
     }
@@ -67,6 +69,18 @@ final class PanConfiguration
     }
 
     /**
+     * Sets the analytic descriptions.
+     *
+     * @param  array<string, string>  $descriptions
+     *
+     * @internal
+     */
+    public function setAnalyticDescriptions(array $descriptions): void
+    {
+        $this->analyticDescriptions = $descriptions;
+    }
+
+    /**
      * Sets the maximum number of analytics to store.
      */
     public static function maxAnalytics(int $number): void
@@ -103,6 +117,16 @@ final class PanConfiguration
     }
 
     /**
+     * Sets the analytics descriptions
+     *
+     * @param  array<string, string>  $descriptions
+     */
+    public static function analyticDescriptions(array $descriptions): void
+    {
+        self::instance()->setAnalyticDescriptions($descriptions);
+    }
+
+    /**
      * Resets the configuration to its default values.
      *
      * @internal
@@ -112,12 +136,18 @@ final class PanConfiguration
         self::maxAnalytics(50);
         self::allowedAnalytics([]);
         self::routePrefix('pan');
+        self::analyticDescriptions([]);
     }
 
     /**
      * Converts the Pan configuration to an array.
      *
-     * @return array{max_analytics: int, allowed_analytics: array<int, string>, route_prefix: string}
+     * @return array{
+     *     max_analytics: int,
+     *     allowed_analytics: array<int, string>,
+     *     route_prefix: string,
+     *     analytic_descriptions: array<string, string>,
+     * }
      *
      * @internal
      */
@@ -127,6 +157,7 @@ final class PanConfiguration
             'max_analytics' => $this->maxAnalytics,
             'allowed_analytics' => $this->allowedAnalytics,
             'route_prefix' => $this->routePrefix,
+            'analytic_descriptions' => $this->analyticDescriptions,
         ];
     }
 }

--- a/src/Presentors/AnalyticPresentor.php
+++ b/src/Presentors/AnalyticPresentor.php
@@ -21,6 +21,7 @@ final class AnalyticPresentor
         return [
             'id' => '<fg=gray>#'.$analytic->id.'</>',
             'name' => '<fg=gray>'.$analytic->name.'</>',
+            'description' => '<fg=gray>'.($analytic->description ?? '-').'</>',
             'impressions' => $this->toHumanReadableNumber($analytic->impressions),
             'hovers' => $this->toHumanReadableNumber($analytic->hovers).' ('.$this->toHumanReadablePercentage($analytic->impressions, $analytic->hovers).')',
             'clicks' => $this->toHumanReadableNumber($analytic->clicks).' ('.$this->toHumanReadablePercentage($analytic->impressions, $analytic->clicks).')',

--- a/src/ValueObjects/Analytic.php
+++ b/src/ValueObjects/Analytic.php
@@ -9,17 +9,13 @@ namespace Pan\ValueObjects;
  */
 final readonly class Analytic
 {
-    /**
-     * Returns all analytics.
-     *
-     * @return array<int, Analytic>
-     */
     public function __construct(
         public int $id,
         public string $name,
         public int $impressions,
         public int $hovers,
         public int $clicks,
+        public ?string $description = null,
     ) {
         //
     }
@@ -27,13 +23,14 @@ final readonly class Analytic
     /**
      * Returns the analytic as an array.
      *
-     * @return array{id: int, name: string, impressions: int, hovers: int, clicks: int}
+     * @return array{id: int, name: string, description: string|null, impressions: int, hovers: int, clicks: int}
      */
     public function toArray(): array
     {
         return [
             'id' => $this->id,
             'name' => $this->name,
+            'description' => $this->description,
             'impressions' => $this->impressions,
             'hovers' => $this->hovers,
             'clicks' => $this->clicks,

--- a/tests/Feature/Laravel/Http/EventsTest.php
+++ b/tests/Feature/Laravel/Http/EventsTest.php
@@ -18,7 +18,7 @@ it('can create an analytic click event', function (): void {
     $analytics = array_map(fn (Analytic $analytic): array => $analytic->toArray(), app(AnalyticsRepository::class)->all());
 
     expect($analytics)->toBe([
-        ['id' => 1, 'name' => 'help-modal', 'impressions' => 0, 'hovers' => 0, 'clicks' => 1],
+        ['id' => 1, 'name' => 'help-modal', 'description' => null, 'impressions' => 0, 'hovers' => 0, 'clicks' => 1],
     ]);
 });
 
@@ -35,7 +35,7 @@ it('can create an analytic hover event', function (): void {
     $analytics = array_map(fn (Analytic $analytic): array => $analytic->toArray(), app(AnalyticsRepository::class)->all());
 
     expect($analytics)->toBe([
-        ['id' => 1, 'name' => 'help-modal', 'impressions' => 0, 'hovers' => 1, 'clicks' => 0],
+        ['id' => 1, 'name' => 'help-modal', 'description' => null, 'impressions' => 0, 'hovers' => 1, 'clicks' => 0],
     ]);
 });
 
@@ -52,7 +52,7 @@ it('can create an analytic impression event', function (): void {
     $analytics = array_map(fn (Analytic $analytic): array => $analytic->toArray(), app(AnalyticsRepository::class)->all());
 
     expect($analytics)->toBe([
-        ['id' => 1, 'name' => 'help-modal', 'impressions' => 1, 'hovers' => 0, 'clicks' => 0],
+        ['id' => 1, 'name' => 'help-modal', 'description' => null, 'impressions' => 1, 'hovers' => 0, 'clicks' => 0],
     ]);
 });
 
@@ -75,7 +75,7 @@ it('can create an analytic impression event and click event', function (): void 
     $analytics = array_map(fn (Analytic $analytic): array => $analytic->toArray(), app(AnalyticsRepository::class)->all());
 
     expect($analytics)->toBe([
-        ['id' => 1, 'name' => 'help-modal', 'impressions' => 1, 'hovers' => 0, 'clicks' => 1],
+        ['id' => 1, 'name' => 'help-modal', 'description' => null, 'impressions' => 1, 'hovers' => 0, 'clicks' => 1],
     ]);
 });
 
@@ -135,7 +135,7 @@ it('can create an event using a custom prefix url', function (): void {
     $analytics = array_map(fn (Analytic $analytic): array => $analytic->toArray(), app(AnalyticsRepository::class)->all());
 
     expect($analytics)->toBe([
-        ['id' => 1, 'name' => 'help-modal', 'impressions' => 1, 'hovers' => 0, 'clicks' => 0],
+        ['id' => 1, 'name' => 'help-modal', 'description' => null, 'impressions' => 1, 'hovers' => 0, 'clicks' => 0],
     ]);
 })->after(function (): void {
     PanConfiguration::routePrefix('pan');

--- a/tests/Unit/Actions/CreateEventTest.php
+++ b/tests/Unit/Actions/CreateEventTest.php
@@ -15,6 +15,6 @@ it('increments the click event for the given analytic', function (): void {
     $analytics = array_map(fn (Analytic $analytic): array => $analytic->toArray(), app(AnalyticsRepository::class)->all());
 
     expect($analytics)->toBe([
-        ['id' => 1, 'name' => 'help-modal', 'impressions' => 0, 'hovers' => 1, 'clicks' => 2],
+        ['id' => 1, 'name' => 'help-modal', 'description' => null, 'impressions' => 0, 'hovers' => 1, 'clicks' => 2],
     ]);
 });

--- a/tests/Unit/PanConfigurationTest.php
+++ b/tests/Unit/PanConfigurationTest.php
@@ -7,6 +7,7 @@ it('have a max of 50 analytics by default', function (): void {
         'max_analytics' => 50,
         'allowed_analytics' => [],
         'route_prefix' => 'pan',
+        'analytic_descriptions' => [],
     ]);
 });
 
@@ -17,6 +18,7 @@ it('can set the max number of analytics to store', function (): void {
         'max_analytics' => 100,
         'allowed_analytics' => [],
         'route_prefix' => 'pan',
+        'analytic_descriptions' => [],
     ]);
 });
 
@@ -27,6 +29,7 @@ it('can set the max number of analytics to unlimited', function (): void {
         'max_analytics' => PHP_INT_MAX,
         'allowed_analytics' => [],
         'route_prefix' => 'pan',
+        'analytic_descriptions' => [],
     ]);
 });
 
@@ -37,6 +40,7 @@ it('can set the allowed analytics names to store', function (): void {
         'max_analytics' => 50,
         'allowed_analytics' => ['help-modal', 'contact-modal'],
         'route_prefix' => 'pan',
+        'analytic_descriptions' => [],
     ]);
 });
 
@@ -45,6 +49,7 @@ it('sets an empty array of allowed analytics names by default', function (): voi
         'max_analytics' => 50,
         'allowed_analytics' => [],
         'route_prefix' => 'pan',
+        'analytic_descriptions' => [],
     ]);
 });
 
@@ -55,18 +60,34 @@ it('can set the prefix url', function (): void {
         'max_analytics' => 50,
         'allowed_analytics' => [],
         'route_prefix' => 'new-pan',
+        'analytic_descriptions' => [],
+    ]);
+});
+
+it('can set the event descriptions', function (): void {
+    PanConfiguration::analyticDescriptions([
+        'help-modal' => 'The Help Modal',
+    ]);
+
+    expect(PanConfiguration::instance()->toArray())->toBe([
+        'max_analytics' => 50,
+        'allowed_analytics' => [],
+        'route_prefix' => 'pan',
+        'analytic_descriptions' => ['help-modal' => 'The Help Modal'],
     ]);
 });
 
 it('may reset the configuration to its default values', function (): void {
     PanConfiguration::maxAnalytics(99);
     PanConfiguration::allowedAnalytics(['help-modal', 'contact-modal']);
+    PanConfiguration::analyticDescriptions(['help-modal' => 'The help modal']);
     PanConfiguration::routePrefix('new-pan');
 
     expect(PanConfiguration::instance()->toArray())->toBe([
         'max_analytics' => 99,
         'allowed_analytics' => ['help-modal', 'contact-modal'],
         'route_prefix' => 'new-pan',
+        'analytic_descriptions' => ['help-modal' => 'The help modal'],
     ]);
 
     PanConfiguration::reset();
@@ -75,5 +96,6 @@ it('may reset the configuration to its default values', function (): void {
         'max_analytics' => 50,
         'allowed_analytics' => [],
         'route_prefix' => 'pan',
+        'analytic_descriptions' => [],
     ]);
 });

--- a/tests/Unit/Presentors/AnalyticPresentorTest.php
+++ b/tests/Unit/Presentors/AnalyticPresentorTest.php
@@ -13,6 +13,7 @@ it('present an analytic', function (): void {
     expect($rows)->toBe([
         'id' => '#1',
         'name' => 'help-modal',
+        'description' => '-',
         'impressions' => '1',
         'hovers' => '1 (100.0%)',
         'clicks' => '1 (100.0%)',
@@ -29,6 +30,7 @@ it('present an analytic with 0 impressions', function (): void {
     expect($rows)->toBe([
         'id' => '#1',
         'name' => 'help-modal',
+        'description' => '-',
         'impressions' => '0',
         'hovers' => '1 (Infinity%)',
         'clicks' => '1 (Infinity%)',
@@ -45,6 +47,7 @@ it('present an analytic with 0 hovers', function (): void {
     expect($rows)->toBe([
         'id' => '#1',
         'name' => 'help-modal',
+        'description' => '-',
         'impressions' => '1',
         'hovers' => '0 (0.0%)',
         'clicks' => '1 (100.0%)',
@@ -61,6 +64,7 @@ it('present an analytic with 0 clicks', function (): void {
     expect($rows)->toBe([
         'id' => '#1',
         'name' => 'help-modal',
+        'description' => '-',
         'impressions' => '1',
         'hovers' => '1 (100.0%)',
         'clicks' => '0 (0.0%)',
@@ -77,6 +81,7 @@ it('presents huge numbers', function (): void {
     expect($rows)->toBe([
         'id' => '#1',
         'name' => 'help-modal',
+        'description' => '-',
         'impressions' => '1,000,000',
         'hovers' => '1,000,000 (100.0%)',
         'clicks' => '1,000,000 (100.0%)',
@@ -93,8 +98,26 @@ it('presents huge numbers with 0 impressions', function (): void {
     expect($rows)->toBe([
         'id' => '#1',
         'name' => 'help-modal',
+        'description' => '-',
         'impressions' => '0',
         'hovers' => '1,000,000 (Infinity%)',
         'clicks' => '1,000,000 (Infinity%)',
+    ]);
+});
+
+it('presents analytic with description', function (): void {
+    $analytic = new Analytic(1, 'help-modal', 1, 1, 1, 'The Help Modal');
+
+    $presentor = new AnalyticPresentor;
+
+    $rows = array_map(fn ($value): string => strip_tags($value), $presentor->present($analytic));
+
+    expect($rows)->toBe([
+        'id' => '#1',
+        'name' => 'help-modal',
+        'description' => 'The Help Modal',
+        'impressions' => '1',
+        'hovers' => '1 (100.0%)',
+        'clicks' => '1 (100.0%)',
     ]);
 });


### PR DESCRIPTION
This PR adds the ability to optionally define a human friendly description for your Analytics.

It taps into the AnalyticRepository and DTO to return the relevant description where it has been defined.

It can be easily set using the existing PanConfiguration helper:

```php
PanConfiguration::analyticDescriptions([
    'button-cta' => 'Call to action button',
]);
```