### PR TITLE
feat: downgrade to PHP8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Visualize your analytics is as simple as typing `php artisan pan` in your termin
 
 ## Get Started
 
-> **Requires [PHP 8.3+](https://php.net/releases/), and [Laravel 11.0+](https://laravel.com)**.
+> **Requires [PHP 8.2+](https://php.net/releases/), and [Laravel 11.0+](https://laravel.com)**.
 
 You may use [Composer](https://getcomposer.org) to require Pan into your PHP project:
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.3.0"
+        "php": "^8.2.0"
     },
     "conflict": {
         "laravel/framework": "<11.0.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #37
| License       | MIT

Hello,

I would like to use your library, but I am stuck on PHP 8.2. I tried running it on PHP 8.2, and all the tests passed successfully.
So, I don’t understand why PHP 8.3 or higher is required.

If you’re open to lowering the requirement, it would make your library accessible to more people.

Thank you, and have a great day!