### PR TITLE
feat: add ability to configure custom `database` connection

### DIFF
--- a/src/Adapters/Laravel/Repositories/DatabaseAnalyticsRepository.php
+++ b/src/Adapters/Laravel/Repositories/DatabaseAnalyticsRepository.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Pan\Adapters\Laravel\Repositories;
 
-use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Connection;
+use Illuminate\Database\DatabaseManager;
 use Pan\Contracts\AnalyticsRepository;
 use Pan\Enums\EventType;
 use Pan\PanConfiguration;
@@ -18,10 +19,10 @@ final readonly class DatabaseAnalyticsRepository implements AnalyticsRepository
     /**
      * Creates a new analytics repository instance.
      */
-    public function __construct(private PanConfiguration $config)
-    {
-        //
-    }
+    public function __construct(
+        private DatabaseManager $db,
+        private PanConfiguration $config
+    ) {}
 
     /**
      * Returns all analytics.
@@ -31,12 +32,12 @@ final readonly class DatabaseAnalyticsRepository implements AnalyticsRepository
     public function all(): array
     {
         /** @var array<int, Analytic> $all */
-        $all = DB::table('pan_analytics')->get()->map(fn (mixed $analytic): Analytic => new Analytic(
-            id: (int) $analytic->id, // @phpstan-ignore-line
-            name: $analytic->name, // @phpstan-ignore-line
-            impressions: (int) $analytic->impressions, // @phpstan-ignore-line
-            hovers: (int) $analytic->hovers, // @phpstan-ignore-line
-            clicks: (int) $analytic->clicks, // @phpstan-ignore-line
+        $all = $this->connection()->table('pan_analytics')->get()->map(fn (mixed $analytic): Analytic => new Analytic(
+            id: (int) $analytic->id,
+            name: $analytic->name,
+            impressions: (int) $analytic->impressions,
+            hovers: (int) $analytic->hovers,
+            clicks: (int) $analytic->clicks,
         ))->toArray();
 
         return $all;
@@ -56,15 +57,15 @@ final readonly class DatabaseAnalyticsRepository implements AnalyticsRepository
             return;
         }
 
-        if (DB::table('pan_analytics')->where('name', $name)->count() === 0) {
-            if (DB::table('pan_analytics')->count() < $maxAnalytics) {
-                DB::table('pan_analytics')->insert(['name' => $name, $event->column() => 1]);
+        if ($this->connection()->table('pan_analytics')->where('name', $name)->count() === 0) {
+            if ($this->connection()->table('pan_analytics')->count() < $maxAnalytics) {
+                $this->connection()->table('pan_analytics')->insert(['name' => $name, $event->column() => 1]);
             }
 
             return;
         }
 
-        DB::table('pan_analytics')->where('name', $name)->increment($event->column());
+        $this->connection()->table('pan_analytics')->where('name', $name)->increment($event->column());
     }
 
     /**
@@ -72,6 +73,14 @@ final readonly class DatabaseAnalyticsRepository implements AnalyticsRepository
      */
     public function flush(): void
     {
-        DB::table('pan_analytics')->truncate();
+        $this->connection()->table('pan_analytics')->truncate();
+    }
+
+    /**
+     * Resolve the database connection.
+     */
+    private function connection(): Connection
+    {
+        return $this->db->connection($this->config->getDatabaseConnection());
     }
 }

--- a/src/PanConfiguration.php
+++ b/src/PanConfiguration.php
@@ -20,6 +20,7 @@ final class PanConfiguration
         private int $maxAnalytics = 50,
         private array $allowedAnalytics = [],
         private string $routePrefix = 'pan',
+        private ?string $databaseConnection = null,
     ) {
         //
     }
@@ -64,6 +65,24 @@ final class PanConfiguration
     public function setRoutePrefix(string $prefix): void
     {
         $this->routePrefix = $prefix;
+    }
+
+    /**
+     * Sets the database connection to be used.
+     *
+     * @internal
+     */
+    public function setDatabaseConnection(string $connection): void
+    {
+        $this->databaseConnection = $connection;
+    }
+
+    /**
+     * Sets the database connection to be used.
+     */
+    public static function databaseConnection(string $connection): void
+    {
+        self::instance()->setDatabaseConnection($connection);
     }
 
     /**
@@ -128,5 +147,15 @@ final class PanConfiguration
             'allowed_analytics' => $this->allowedAnalytics,
             'route_prefix' => $this->routePrefix,
         ];
+    }
+
+    /**
+     * Get the database connection to be used.
+     *
+     * @internal
+     */
+    public function getDatabaseConnection(): ?string
+    {
+        return $this->databaseConnection;
     }
 }

--- a/tests/Unit/PanConfigurationTest.php
+++ b/tests/Unit/PanConfigurationTest.php
@@ -77,3 +77,9 @@ it('may reset the configuration to its default values', function (): void {
         'route_prefix' => 'pan',
     ]);
 });
+
+it('can set the database connection', function (): void {
+    PanConfiguration::databaseConnection('sqlite');
+
+    expect(PanConfiguration::instance()->getDatabaseConnection())->toBe('sqlite');
+});


### PR DESCRIPTION
This pull request includes several changes to the `DatabaseAnalyticsRepository` and `PanConfiguration` classes to enhance database connection handling. The most important changes include updating the constructor and methods in `DatabaseAnalyticsRepository` to use the `DatabaseManager` for database operations, and adding methods to `PanConfiguration` for setting and getting the database connection.

### Enhancements to database connection handling:

* Updated the constructor to inject `DatabaseManager` and replaced direct `DB` facade calls with `$this->connection()` method to use the configured database connection. 
* Added a private `connection()` method to resolve the database connection using the configuration.

### PanConfiguration:

Added a `databaseConnection` property and methods to set and get the database connection.

### Unit tests:

* Added a test to verify the `databaseConnection` can be set and retrieved correctly.