### PR TITLE
fix upercase 'utf' in 'InjectJavascriptLibrary' Middleware

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/src/Adapters/Laravel/Http/Middleware/InjectJavascriptLibrary.php
+++ b/src/Adapters/Laravel/Http/Middleware/InjectJavascriptLibrary.php
@@ -33,7 +33,7 @@ final readonly class InjectJavascriptLibrary
         /** @var Response $response */
         $response = $next($request);
 
-        if ($response->headers->get('Content-Type') === 'text/html; charset=UTF-8') {
+        if (strtolower($response->headers->get('Content-Type') ?? '') === 'text/html; charset=utf-8') {
             $content = (string) $response->getContent();
 
             if (! str_contains($content, '</html>') || ! str_contains($content, '</body>')) {


### PR DESCRIPTION
 i currently working on a project and i needed a lightweight analytics pan was perfect for me . i went straight forward but i had some issues the front end doesn't fire the request to send data to the server then i began to debug and find out that 
the Middleware InjectJavascriptLibrary has a condition that check if the content type header is 'text/html; charset=UTF-8' but my dev server was return it  'text/html; charset=utf-8' 
so i fixed it by lowercase whatever the server return and compare it to 'text/html; charset=utf-8'
<img width="1920" height="1152" alt="pan" src="https://github.com/user-attachments/assets/22bc34f8-215d-4c17-b240-d217560e4633" />
